### PR TITLE
Overhaul Screen Refresh Process/Thread Widgets (#6)

### DIFF
--- a/Modules/DBusMain.py
+++ b/Modules/DBusMain.py
@@ -1,0 +1,18 @@
+import __main__
+from threading import Thread
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+from gi.repository import GObject
+
+try:
+    DBusGMainLoop(set_as_default=True)
+    GObject.threads_init()
+    dbus.mainloop.glib.threads_init()
+    dbus_loop = DBusGMainLoop()
+    DBUS_BUS = dbus.SystemBus(mainloop=dbus_loop)
+    MAINLOOP = GLib.MainLoop()
+    DBUS_THREAD = Thread(target=MAINLOOP.run, daemon=True)
+    DBUS_THREAD.start()
+except:
+    print("Error Loading DBus, functionality will be reduced!")

--- a/Modules/GenWidgets/Icon.py
+++ b/Modules/GenWidgets/Icon.py
@@ -19,11 +19,9 @@ class Icon(Button):
             self.size = self.image.get_rect()
         self.size = (self.size[0]+20, self.size[1]+20)
         self.function = function
-        
-        
         self.surface = pygame.Surface((self.size[0], self.size[1]), pygame.SRCALPHA)
         self.surface_rect = self.surface.get_rect(topleft=self.pos)
-    
+
     def draw(self, surf):
         # empty fill to clear what's been drawn
         self.surface.fill((0,0,0,0))
@@ -41,4 +39,4 @@ class Icon(Button):
             self.surface.blit(text, text_rect)
 
         surf.blit(self.surface, self.surface_rect)
-            
+

--- a/Modules/GenWidgets/Nav.py
+++ b/Modules/GenWidgets/Nav.py
@@ -18,7 +18,7 @@ class Nav():
                 page=Pages.APPS,
                 image='powerIcon.png',
                 pos=(
-                    EDGE_PADDING, 
+                    EDGE_PADDING,
                     self.parent.screen.get_height() - 22 - EDGE_PADDING
                 ),
                 size=(45,22),
@@ -31,7 +31,7 @@ class Nav():
                 page=Pages.POWER,
                 image='nextIcon.png',
                 pos=(
-                    self.parent.screen.get_width() - 64, 
+                    self.parent.screen.get_width() - 64,
                     self.parent.screen.get_height()/2 - 32
                 ),
                 size=(64,64),
@@ -46,7 +46,7 @@ class Nav():
                 page=Pages.APPS,
                 image='settingsIcon.png',
                 pos=(
-                    self.parent.screen.get_width() - 45 - EDGE_PADDING, 
+                    self.parent.screen.get_width() - 45 - EDGE_PADDING,
                     self.parent.screen.get_height() - 22 - EDGE_PADDING
                 ),
                 size=(45,22),
@@ -61,7 +61,7 @@ class Nav():
                 page=Pages.SETTINGS,
                 image='backIcon.png',
                 pos=(
-                    0, 
+                    0,
                     self.parent.screen.get_height()/2 - 32
                 ),
                 size=(64,64),
@@ -76,6 +76,7 @@ class Nav():
 
 
     def goToPage(self, menu, direction=None, page=None):
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
         if page and 1 <= page <= len(menu.pages):
             menu.active_page = page
         else:
@@ -87,20 +88,21 @@ class Nav():
                 menu.active_page += 1
                 if menu.active_page >= len(menu.pages):
                     menu.active_page = len(menu.pages)
+
     def do(self, event):
         if self.parent.visible:
             for button in self.buttons:
                 button.do(event)
-
-    def update(self):
         if self.visible:
-            # update widgets
             for widget in self.widgets:
                 if widget.page == self.parent.active_page or widget.persistent:
                     widget.update()
 
+    def update(self):
+        pass
+
     def draw(self, surf):
-        if self.visible:
+        if self.visible is True:
             # draw page title
             font = pygame.font.Font(FONT_LATO,20)
             text = font.render(self.parent.pages[self.parent.active_page-1].title, True, (255, 255, 255))

--- a/Modules/GenWidgets/Widget.py
+++ b/Modules/GenWidgets/Widget.py
@@ -22,7 +22,7 @@ class Slider():
 
         self.handle_width = 10
         self.handle_x = ((self.size[0]/self.max)*self.value) - (self.handle_width/2)
-        
+
     def setValue(self, value):
         print('Setting the value to {}'.format(value))
         self.value = int(round(value, 0))
@@ -46,7 +46,7 @@ class Slider():
         font = pygame.font.Font(FONT_LATO,14)
         if self.label:
             text_string = '{}: {}'.format(self.label, self.value)
-        else: 
+        else:
             text_string = str(self.value)
         rendered_text = font.render(text_string, True, (255,255,255))
         text_rect = rendered_text.get_rect(midtop=(self.size[0]/2,0))
@@ -56,7 +56,7 @@ class Slider():
         if self.icons:
             icon_size = (24,24)
             positions = [self.pos, (self.pos[0] + self.size[0] - icon_size[0], self.pos[1])] # left, right
-            for index,icon in enumerate(self.icons): 
+            for index,icon in enumerate(self.icons):
                 icon_asset = pygame.image.load(assetpath(icon)).convert_alpha()
                 image = pygame.transform.scale(icon_asset, icon_size)
                 surf.blit(image, positions[index])
@@ -71,10 +71,12 @@ class Slider():
                 slider_width = self.size[0]
                 clicked_pos = mouse[0] - self.pos[0]
                 self.setValue((self.max/slider_width) * clicked_pos)
+                pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
             if event.type == pygame.MOUSEBUTTONUP:
-                if self.function != None: 
+                if self.function != None:
                     print('clicked Slider "{}"'.format(self.label))
                     self.function()
+                    pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
 class ConfirmDialog():
     def __init__(self, parent=None, message='Are you sure?', options=None):
@@ -109,7 +111,7 @@ class ConfirmDialog():
     def draw(self, surf):
         # empty fill to clear what's been drawn
         self.surface.fill((0,0,0,0))
-        
+
         # draw a background fill
         dialog_rect = pygame.Rect(0,0, self.size[0], self.size[1], topleft=(0,0))
         pygame.draw.rect(self.surface, (100,100,100), dialog_rect)
@@ -118,7 +120,7 @@ class ConfirmDialog():
             text = pygame.font.Font(FONT_LATO, 20).render(self.message, True, (255,255,255))
             if self.buttons:
                 text_rect = text.get_rect(center=(self.size[0]/2, 40))
-            else: 
+            else:
                 text_rect = text.get_rect(center=(self.size[0]/2, self.size[1]/2))
             self.surface.blit(text, text_rect)
 
@@ -128,11 +130,13 @@ class ConfirmDialog():
 
     def show(self):
         self.visible = True
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
     def hide(self):
         self.visible = False
         self.parent.dialog = None
-    
+        pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+
     def do(self, event):
         for button in self.buttons:
             button.do(event)
@@ -143,15 +147,14 @@ class Button():
         self.pos = pos
         self.size = size
         self.function = function
-        
         self.surface = pygame.Surface(self.size, pygame.SRCALPHA)
         self.surface_rect = self.surface.get_rect(center=self.pos)
-    
+
     def do(self, event):
         if event.type == pygame.MOUSEBUTTONUP:
             mouse = pygame.mouse.get_pos()
             if within_bounds(mouse, self.surface_rect):
-                if self.function != None: 
+                if self.function != None:
                     print('clicked Button "{}"'.format(self.function))
                     self.function()
 
@@ -165,7 +168,6 @@ class TextButton():
         self.fillcolor = fillcolor
         self.bordercolor = bordercolor
         self.textcolor = textcolor
-        
 
         if self.text:
             self.rendered_text = pygame.font.Font(FONT_LATO,20).render(self.text, True, self.textcolor)
@@ -173,10 +175,10 @@ class TextButton():
             # if we're not using a specific size, work it out based on the text
             if not self.size:
                 self.size = (
-                    self.rendered_text.get_width() + BUTTON_PADDING[0] + BUTTON_PADDING[2], 
+                    self.rendered_text.get_width() + BUTTON_PADDING[0] + BUTTON_PADDING[2],
                     self.rendered_text.get_height() + BUTTON_PADDING[1] + BUTTON_PADDING[3]
                 )
-            
+
         self.surface = pygame.Surface(self.size, pygame.SRCALPHA)
         self.surface_rect = pygame.Rect(self.pos[0], self.pos[1], self.size[0], self.size[1])
         self.surface_rect.center=self.pos
@@ -193,7 +195,7 @@ class TextButton():
         # draw the text
         if self.rendered_text:
             self.surface.blit(
-                self.rendered_text, 
+                self.rendered_text,
                 (
                     (self.size[0]/2)-(self.rendered_text.get_width()/2),
                     (self.size[1]/2)-(self.rendered_text.get_height()/2)
@@ -201,13 +203,14 @@ class TextButton():
             )
         # blit button to surf
         surf.blit(self.surface, self.surface_rect)
-    
+
     def do(self, event):
         if event.type == pygame.MOUSEBUTTONUP:
             if within_bounds(pygame.mouse.get_pos(), self.surface_rect):
                 if self.function != None:
                     print('clicked TextButton "{}"'.format(self.text))
                     self.function()
+                    pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
 
 class PageButton(Button):
     def __init__(self, parent=None, image=None, pos=(0,0), size=(0,0), page=None, function=None):
@@ -219,7 +222,7 @@ class PageButton(Button):
         self.function = function
         self.surface = pygame.Surface(self.size, pygame.SRCALPHA)
         self.surface_rect = self.surface.get_rect(topleft=self.pos)
-    
+
     def draw(self, surf):
         # empty fill to clear what's been drawn
         self.surface.fill((0,0,0,0))

--- a/Modules/NavWidgets/Battery.py
+++ b/Modules/NavWidgets/Battery.py
@@ -1,45 +1,89 @@
 import pygame
 from Modules.Globals import *
+import Modules.DBusMain as DBusMain
+import dbus
 from Modules.GenWidgets.Widget import *
-if IS_LINUX:
-    import psutil
+from multiprocessing import Value
 
 class Battery(Widget):
     def __init__(self, parent=None):
         self.parent = parent
         self.size = (24, 24)
         self.pos = (EDGE_PADDING, EDGE_PADDING)
-        self.battery_present = False
         self.image = None
         self.page = None
-        self.persistent = True # always draw
-        
-        if IS_LINUX:
-            if psutil.sensors_battery() is not None:
-                self.battery_present = True
-        else:
-            # on other platforms just show an icon 
-            self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-100.png')).convert_alpha(), self.size)
-    def update(self):
-        if self.battery_present is False:
-            return
+        self.persistent = True
+        self.battery_capacity = Value('i', 100)
+        self.battery_charging = Value('i', 1)
 
-        battery_data = psutil.sensors_battery()
-        if battery_data is None:
+        try:
+            if self.check_battery():
+                self.persistent = True
+                self.get_battery_details(self.battery_charging, self.battery_capacity)
+                DBusMain.DBUS_BUS.add_signal_receiver(self.dbus_signal_handler,
+                                                      bus_name='org.freedesktop.UPower',
+                                                      dbus_interface='org.freedesktop.DBus.Properties',
+                                                      signal_name='PropertiesChanged',
+                                                      path='/org/freedesktop/UPower/devices/DisplayDevice')
+        except:
+            self.persistent = False
+
+    def check_battery(self):
+        proxy = DBusMain.DBUS_BUS.get_object('org.freedesktop.UPower',
+                               '/org/freedesktop/UPower/devices/DisplayDevice')
+        powerdev = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        return bool(powerdev.Get('org.freedesktop.UPower.Device','IsPresent'))
+
+    def dbus_signal_handler(self, interface, data, type):
+        update = False
+        if 'State' in data and int(data['State']) != self.battery_charging.value:
+            self.battery_charging.value = int(data['State'])
+            update = True
+        if 'Percentage' in data and int(data['Percentage']) != self.battery_capacity.value:
+            self.battery_capacity.value = int(data['Percentage'])
+            update = True
+        if update is True:
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update = False
+        return
+
+    def get_battery_details(self, charging, capacity):
+        proxy = DBusMain.DBUS_BUS.get_object('org.freedesktop.UPower',
+                               '/org/freedesktop/UPower/devices/DisplayDevice')
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        update_battery = False
+        try:
+            new_capacity = int(getmanager.Get('org.freedesktop.UPower.Device', 'Percentage'))
+            if new_capacity != capacity.value:
+                capacity.value = new_capacity
+                update_battery = True
+            new_status = int(getmanager.Get('org.freedesktop.UPower.Device','State'))
+            if new_status != charging.value:
+                charging.value = new_status
+                update_battery = True
+        except:
+            print("Error reading battery")
+        if update_battery is True:
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update_battery = False
+        return None
+
+    def update(self):
+        if self.persistent is False:
             return
-        if battery_data.power_plugged is True:
+        if self.battery_charging.value == 1:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-charging.png')).convert_alpha(), self.size)
             return
-        if battery_data.percent > 75:
+        if self.battery_capacity.value > 75:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-100.png')).convert_alpha(), self.size)
             return
-        if battery_data.percent > 50:
+        if self.battery_capacity.value > 50:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-75.png')).convert_alpha(), self.size)
             return
-        if battery_data.percent > 25:
+        if self.battery_capacity.value > 25:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-50.png')).convert_alpha(), self.size)
             return
         else:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('battery-25.png')).convert_alpha(), self.size)
-
+            return
 

--- a/Modules/NavWidgets/Bluetooth.py
+++ b/Modules/NavWidgets/Bluetooth.py
@@ -1,10 +1,9 @@
 import pygame
 from Modules.Globals import *
+import Modules.DBusMain as DBusMain
+import dbus
 from Modules.GenWidgets.Widget import *
-
-if IS_LINUX:
-    # specific imports here
-    pass
+from multiprocessing import Value
 
 class Bluetooth(Widget):
     def __init__(self, parent=None):
@@ -13,20 +12,64 @@ class Bluetooth(Widget):
         self.pos = (self.parent.parent.screen.get_width() - self.size[0] - SPACE_PADDING - self.parent.widgets[1].size[0] - EDGE_PADDING, EDGE_PADDING)
         self.image = None
         self.page = None
-        self.persistent = True # always draw
+        self.persistent = False
         self.bt_device = None
+        self.bluetooth_connect = Value('i', 0)
+        self.bluetooth_power = Value('i', 1)
 
-        if IS_LINUX:
-           # init the bt icon here
-           # self.bt_device = Foo
-           pass
-        else:
-            # on other platforms just show an icon 
-            self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-connected.png')).convert_alpha(), self.size)
+        try:
+            self.get_bluetooth_device()
+            self.get_bluetooth_state()
+            DBusMain.DBUS_BUS.add_signal_receiver(self.dbus_signal_handler,
+                                                  bus_name='org.bluez',
+                                                  dbus_interface='org.freedesktop.DBus.Properties',
+                                                  signal_name='PropertiesChanged',
+                                                  path=self.bt_device)
+            self.persistent = True
+        except:
+            self.persistent = False
+
+    def dbus_signal_handler(self, interface, data, type):
+        update = False
+        if 'Powered' in data and int(data['Powered']) != self.bluetooth_power.value:
+            self.bluetooth_power.value = int(data['Powered'])
+            update = True
+        if 'Connected' in data and int(data['Connected']) != self.bluetooth_connect.value:
+            self.bluetooth_connect.value = int(data['Connected'])
+            update = True
+        if update is True:
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update = False
+        return
+
+    def get_bluetooth_device(self):
+        proxy = DBusMain.DBUS_BUS.get_object('org.bluez','/')
+        get_manager = dbus.Interface(proxy, 'org.freedesktop.DBus.ObjectManager')
+        objects = get_manager.GetManagedObjects()
+        for item in objects:
+            if 'org.bluez.Adapter1' in objects[item]:
+                self.bt_device = item
+
+    def get_bluetooth_state(self):
+        try:
+            proxy = DBusMain.DBUS_BUS.get_object('org.bluez',self.bt_device)
+            get_manager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+            self.bluetooth_power.value = int(get_manager.Get('org.bluez.Adapter1','Powered'))
+        except:
+            self.bluetooth_power.value = 0
+        try:
+            proxy = DBusMain.DBUS_BUS.get_object('org.bluez',bt_object_path)
+            get_manager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+            self.bluetooth_connect.value = int(get_manager.Get('org.bluez.Device1','Connected'))
+        except:
+            self.bluetooth_connect.value = 0
 
     def update(self):
-        if self.bt_device is None:
+        if self.bt_device is None or self.persistent is False:
+            return
+        if self.bluetooth_connect.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-disconnected.png')).convert_alpha(), self.size)
             return
         else:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('bluetooth-connected.png')).convert_alpha(), self.size)
+            return

--- a/Modules/NavWidgets/Wifi.py
+++ b/Modules/NavWidgets/Wifi.py
@@ -1,9 +1,9 @@
 import pygame
 from Modules.Globals import *
+import Modules.DBusMain as DBusMain
+import dbus
 from Modules.GenWidgets.Widget import *
-
-if IS_LINUX:
-    from NetworkManager import NetworkManager
+from multiprocessing import Value
 
 class Wifi(Widget):
     def __init__(self, parent=None):
@@ -12,30 +12,88 @@ class Wifi(Widget):
         self.pos = (self.parent.parent.screen.get_width() - self.size[0] - EDGE_PADDING, EDGE_PADDING)
         self.image = None
         self.page = None
-        self.persistent = True # always draw
+        self.persistent = True
         self.wifi_device = None
+        self.wifi_connection = None
+        self.wifi_signal = Value('i', 100)
+        self.wifi_status = Value('i', 1)
 
-        if IS_LINUX:
-            for device in NetworkManager.GetAllDevices():
-                if device.DeviceType == 2:
-                    self.wifi_device = device
-        else:
-            # on other platforms just show an icon 
-            self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-100.png')).convert_alpha(), self.size)
+        try:
+            self.get_wifi_dev()
+            self.persistent = True
+        except:
+            self.persistent = False
+        if self.wifi_device is not None:
+            try:
+                self.get_active_wifi_connection()
+                DBusMain.DBUS_BUS.add_signal_receiver(self.dbus_signal_handler,
+                                                      bus_name='org.freedesktop.NetworkManager',
+                                                      dbus_interface='org.freedesktop.DBus.Properties',
+                                                      signal_name='PropertiesChanged',
+                                                      path=self.wifi_device)
+            except:
+                self.wifi_connection = None
+        if self.wifi_connection is not None:
+            try:
+                self.get_wifi_connection_strength()
+                DBusMain.DBUS_BUS.add_signal_receiver(self.dbus_signal_handler,
+                                                      bus_name='org.freedesktop.NetworkManager',
+                                                      dbus_interface='org.freedesktop.DBus.Properties',
+                                                      signal_name='PropertiesChanged',
+                                                      path=self.wifi_connection)
+            except:
+                self.wifi_signal = 0
+
+    def dbus_signal_handler(self, interface, data, type):
+        #added print for testing
+        print(data)
+        update = False
+        if 'Strength' in data and int(data['Strength']) != self.wifi_signal.value:
+            self.wifi_signal.value = int(data['Strength'])
+            update = True
+        if 'ActiveAccessPoint' in data and str(data['ActiveAccessPoint']) != self.wifi_connection:
+            self.wifi_connection = str(data['ActiveAccessPoint'])
+            update = True
+        if update is True:
+            #added print for testing
+            print("Updated")
+            pygame.fastevent.post(pygame.event.Event(pygame.USEREVENT, type="screen_update"))
+            update = False
+
+    def get_wifi_dev(self):
+        proxy = DBusMain.DBUS_BUS.get_object('org.freedesktop.NetworkManager',
+                                             '/org/freedesktop/NetworkManager')
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.NetworkManager')
+        devices = getmanager.GetDevices()
+        for device in devices:
+            deviceobject = DBusMain.DBUS_BUS.get_object('org.freedesktop.NetworkManager',device)
+            deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.DBus.Properties')
+            if deviceinterface.Get('org.freedesktop.NetworkManager.Device', 'DeviceType') == 2:
+                self.wifi_device = device
+
+    def get_active_wifi_connection(self):
+        proxy = DBusMain.DBUS_BUS.get_object('org.freedesktop.NetworkManager', self.wifi_device)
+        getmanager = dbus.Interface(proxy, dbus_interface='org.freedesktop.DBus.Properties')
+        self.wifi_connection = str(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','ActiveAccessPoint'))
+
+    def get_wifi_connection_strength(self):
+        apobject = DBusMain.DBUS_BUS.get_object('org.freedesktop.NetworkManager', self.wifi_connection)
+        apinterface = dbus.Interface(apobject,dbus_interface='org.freedesktop.DBus.Properties')
+        self.wifi_signal.value = int(apinterface.Get('org.freedesktop.NetworkManager.AccessPoint', 'Strength'))
 
     def update(self):
-        if self.wifi_device is None:
+        if self.wifi_device is None or self.persistent is False:
             return
-        if self.wifi_device.ActiveConnection is None:
+        if self.wifi_status.value == 0:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-disconnected.png')).convert_alpha(), self.size)
             return
-        if self.wifi_device.ActiveConnection.Devices[0].ActiveAccessPoint.Strength > 75:
+        if self.wifi_signal.value > 75:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-100.png')).convert_alpha(), self.size)
             return
-        if self.wifi_device.ActiveConnection.Devices[0].ActiveAccessPoint.Strength > 50:
+        if self.wifi_signal.value > 50:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-75.png')).convert_alpha(), self.size)
             return
-        if self.wifi_device.ActiveConnection.Devices[0].ActiveAccessPoint.Strength > 25:
+        if self.wifi_signal.value > 25:
             self.image = pygame.transform.scale(pygame.image.load(assetpath('wifi-50.png')).convert_alpha(), self.size)
             return
         else:

--- a/Modules/Screens/Apps.py
+++ b/Modules/Screens/Apps.py
@@ -3,7 +3,6 @@ import os
 from Modules.Globals import *
 from Modules.GenWidgets.Icon import *
 
-
 class Apps():
     index = Pages.APPS
     title = 'Apps'
@@ -26,7 +25,7 @@ class Apps():
         self.parent = parent
         self.image = assetpath('mainBackground.png')
         self.collate_apps()
-     
+
         wrap_at = 3
         wrap_counter = -1
         start_x = 80 # can probably calculate this to make this more scalable.
@@ -42,7 +41,7 @@ class Apps():
                 wrap_counter += 1
                 row_offset = start_y + (row_height * wrap_counter)
             else:
-                col_offset += col_width # new col 
+                col_offset += col_width # new col
 
             pos = (col_offset, row_offset)
             size = (64, 64)
@@ -57,11 +56,10 @@ class Apps():
                 )
             )
 
-
     def do(self, event):
         for icon in self.icons:
             icon.do(event)
-                        
+
     def update(self):
         pass
 

--- a/Modules/Screens/Power.py
+++ b/Modules/Screens/Power.py
@@ -68,7 +68,7 @@ class Power():
                 size=icon_size,
                 function=icon_data[3],
                 pos=(
-                    int(x_padding * (index + 1)) + (icon_size[0] * index), 
+                    int(x_padding * (index + 1)) + (icon_size[0] * index),
                     int(y_padding)
                 )
             ))
@@ -88,6 +88,6 @@ class Power():
     def draw(self, surf):
         for icon in self.icons:
             icon.draw(surf)
-    
+
 if __name__ == '__main__':
     pass

--- a/dbustest.py
+++ b/dbustest.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+
+import dbus
+bus = dbus.SystemBus()
+
+def get_active_wifis():
+    array_of_wifi_devs = []
+    proxy = bus.get_object('org.freedesktop.NetworkManager',
+        '/org/freedesktop/NetworkManager')
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.NetworkManager')
+    devices = getmanager.GetDevices()
+    for device in devices:
+        deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
+        deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.DBus.Properties')
+        if deviceinterface.Get('org.freedesktop.NetworkManager.Device', 'DeviceType') == 2:
+            array_of_wifi_devs.append(device)
+
+    return array_of_wifi_devs
+
+def get_scan_results(array_of_wifi_devs):
+    array_of_aps = []
+    for device in array_of_wifi_devs:
+        deviceobject = bus.get_object('org.freedesktop.NetworkManager',device)
+        deviceinterface = dbus.Interface(deviceobject, dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
+        for accesspoint in deviceinterface.GetAllAccessPoints():
+            array_of_aps.append(str(accesspoint))
+    return array_of_aps
+
+def human_readable_ap_info(array_of_aps):
+    array_of_readable_aps = []
+    for accesspoint in array_of_aps:
+        apobject = bus.get_object('org.freedesktop.NetworkManager',accesspoint)
+        apinterface = dbus.Interface(apobject,dbus_interface='org.freedesktop.DBus.Properties')
+        ap = apinterface.GetAll('org.freedesktop.NetworkManager.AccessPoint')
+        ap_info = {}
+        ap_info['name'] = ''.join([chr(byte) for byte in ap['Ssid']])
+        ap_info['strength'] = int(ap['Strength'])
+        if int(ap['Flags']) & 0x1 == 1:
+            ap_info['encrypted'] = True
+        else:
+            ap_info['encrypted'] = False
+        array_of_readable_aps.append(ap_info)
+    return array_of_readable_aps
+
+def get_active_wifi_connection():
+    proxy = bus.get_object('org.freedesktop.NetworkManager',
+        '/org/freedesktop/NetworkManager')
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+    for connection in getmanager.Get('org.freedesktop.NetworkManager', 'ActiveConnections'):
+        connectionobject = bus.get_object('org.freedesktop.NetworkManager',
+                    connection)
+        conmanager = dbus.Interface(connectionobject, 'org.freedesktop.DBus.Properties')
+        if conmanager.Get('org.freedesktop.NetworkManager.Connection.Active', 'State') in [1,2,3] and \
+            conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','Type') == '802-11-wireless':
+            return [str(conmanager.Get('org.freedesktop.NetworkManager.Connection.Active','SpecificObject'))]
+
+def initiate_ap_scan(array_of_wifi_devs, current_time_monotonic=None):
+    last_scan_times_monotonic = []
+    for wifi_dev in array_of_wifi_devs:
+        proxy = bus.get_object('org.freedesktop.NetworkManager',
+            wifi_dev)
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        if current_time_monotonic is None or int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')) < current_time_monotonic - 20000:
+            getmanager = dbus.Interface(proxy,dbus_interface='org.freedesktop.NetworkManager.Device.Wireless')
+            getmanager.RequestScan({})
+        getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+        last_scan_times_monotonic.append(int(getmanager.Get('org.freedesktop.NetworkManager.Device.Wireless','LastScan')))
+    return int(sum(last_scan_times_monotonic) / len(last_scan_times_monotonic))
+
+def get_battery():
+    proxy = bus.get_object('org.freedesktop.UPower','/org/freedesktop/UPower')
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.UPower')
+    for power_device in getmanager.EnumerateDevices():
+        powerobj = bus.get_object('org.freedesktop.UPower',power_device)
+        powerdev = dbus.Interface(powerobj,'org.freedesktop.DBus.Properties')
+        if powerdev.Get('org.freedesktop.UPower.Device','Type') == 2:
+            return power_device
+    return None
+
+def refresh_power_details(power_device):
+    proxy = bus.get_object('org.freedesktop.UPower',power_device)
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.UPower.Device')
+    getmanager.Refresh()
+    return None
+
+def get_battery_details(power_device):
+    battery_details = {}
+    proxy = bus.get_object('org.freedesktop.UPower',power_device)
+    getmanager = dbus.Interface(proxy, 'org.freedesktop.DBus.Properties')
+    battery_details['percent'] = getmanager.Get('org.freedesktop.UPower.Device','Percentage')
+    if int(getmanager.Get('org.freedesktop.UPower.Device','State')) == 1:
+        battery_details['status'] = 'charging'
+    else:
+        battery_details['status'] = 'not-charging'
+    return battery_details
+
+#start a site survey
+#wifi_devices = get_active_wifis()
+#last_scan_time = initiate_ap_scan(wifi_devices)
+
+#read a site survey
+#wifi_devices = get_active_wifis()
+#access_points = get_scan_results(wifi_devices)
+#print(human_readable_ap_info(access_points))
+
+#read existing connection
+#active_connection = get_active_wifi_connection()
+#print(human_readable_ap_info(active_connection))
+
+battery = get_battery()
+refresh_power_details(battery)
+print(get_battery_details(battery))

--- a/load.sh
+++ b/load.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd /home/chip/pocketchip-menu/
-unclutter &
+#unclutter &
 python3 main.py


### PR DESCRIPTION
* Settings: hook up backlight for settings page

This uses a simple os directory traversal in sysfs to find the current value of the backlight, and it uses a dbus call to set the value of the backlight (to avoid using root). I also changed the slider class to avoid using floats.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* Add DBUS testing commands as I work out the wifi bits.

* main: Make main program executable

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* main: Switch to fastevent

Change the program to use fastevent (instead of event) so we can utilize multi-threading. Change the way we get events from wait which pauses execution until an event is available to get which returns a list of all available events (or an empty list) at every cycle. Change the main event handler to deal with an event list instead of an event object.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* wifi: Make module not fail when cannot query networkmanager

On one of my test machines I have networkmanager, but do not have it running. Make this condition non-fatal.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* widgets: Make widget updates backgrounded/threaded

Widgets will now update according to helper threads. Additionally they send a signal to their parent that there was a change so the parent can more intelligently refresh itself to improve performance.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* pocketchip-menu: main: overhaul page refresh process

Use the event queue to notify when the screen needs to be refreshed and only then should we redraw the screen. This took my CPU utilization down below 1 percent for the program at idle. Note I also changed the refresh to 10FPS, but this can probably be adjusted as needed.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* main: Tweak screen refreshes for faster performance

Make the entire screen refresh process dependent on certain events. This adds a bit more performance.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* test: Add additional helper functions to dbustest

Adds some more dbus functions to the dbustest.py file to test out capturing battery information.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

* dbus: Switch All Widgets to DBus Listener Refresh

All widgets (Bluetooth, Battery and Wifi) now only update when DBus signal handlers tell them an update was sent.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>